### PR TITLE
wrong status code in documenatation after DCC post

### DIFF
--- a/api/quicktest-openapi-dcc.json
+++ b/api/quicktest-openapi-dcc.json
@@ -148,7 +148,7 @@
           "required": true
         },
         "responses": {
-          "201": {
+          "200": {
             "description": "DCC created",
             "content": {
               "application/json": {


### PR DESCRIPTION
usage shows that the result is always HTTP status code 200 instead of 201. Correction in api description would be nice.