### PR TITLE
fixed testcenter_simulator config according to EU specifications, bug…

### DIFF
--- a/src/testcenter_simulator/config.json
+++ b/src/testcenter_simulator/config.json
@@ -23,7 +23,6 @@
                 "ma": "1232",
                 "sc": "2021-06-01T12:34:56Z (wird geändert)",
                 "tr": "260415000",
-                "nm": "ACME Schnelltest",
                 "tc": "Beispiel Test Center",
                 "co": "DE",
                 "is": "Test Issuer",

--- a/src/testcenter_simulator/labsimulator.py
+++ b/src/testcenter_simulator/labsimulator.py
@@ -1,7 +1,7 @@
 from time import sleep
 import logging
 from argparse import ArgumentParser
-from os import urandom as random_bytes # This is test, we don't need strong crypto
+from os import urandom as random_bytes
 import random
 import string
 from cryptography.hazmat.primitives.serialization import load_pem_public_key
@@ -19,7 +19,9 @@ from datetime import datetime
 from time import time, sleep
 
 
-
+class LatinCharError(Exception):
+    """Raised when the input value is not a Latin Character"""
+    pass
 
 
 class LabSimulator:
@@ -41,7 +43,6 @@ class LabSimulator:
         "Erstellt eine Antwort auf einen DCC-Antrag"
 
         # Zufälligen Schlüssel erzeugen
-        # (Achtung! Pseudo-Zufallszahlen! Dies ist nur zum Testen)
         dek = random_bytes(32)
 
         # Payload aus testresults-Verzeichnis übernehmen oder zufällige Payload erzeugen
@@ -52,7 +53,7 @@ class LabSimulator:
         except:
             logging.info("Using random negative test result")
             dcc_data = self._random_dgc_data()
-            dcc_data['t'][0]['ci'] = dcci
+
 
         logging.info(f'DCC-DATA = {dcc_data}')
 
@@ -263,9 +264,13 @@ class LabSimulator:
 
         for s in string:
             if s in transl:
-                string=string.replace(s,transl[s])
+                string=string.replace(s,transl[s])              
             else:
-                logging.warning(f'Name contains non latin character {s}. Handle such input with error in production')
+                if s.isascii():
+                    logging.debug(f'No conversion needed for character {s}')  
+                else:
+                    logging.error(f'Name contains non-latin character {s}.')
+                    raise LatinCharError
         return string
         
         


### PR DESCRIPTION
config.json did contain t/nm, according to [EU specifications](https://ec.europa.eu/health/sites/default/files/ehealth/docs/covid-certificate_json_specification_en.pdf) this is not allowed for RAT.
Proposed fix: remove t/nm element from json

The ICAO character conversion generated warnings for all characters of the Latin alphabet, as they do not have to be converted and thus are not keys in the transl dictionary. 
Proposed fix: 
Check if character is in tranls keys, if yes replace, if no then:
Check if character is ascii, if yes everything is fine, if no then raise custom "LatinCharError" Exception.

Further: 
I don't understand why the os.urandom(32) function should not be used for the AES key generation. urandom should be perfectly safe as it uses entropy supplied by the operating system.